### PR TITLE
Add functions to get data from the API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
+    assertthat,
     dplyr,
     httr2
 URL: http://www.michaellydeamore.com/populaR/

--- a/R/api_key.R
+++ b/R/api_key.R
@@ -1,0 +1,14 @@
+#' @export
+set_wpp_api_key <- function(key) {
+  Sys.setenv(WPP_API_KEY = key)
+}
+
+check_wpp_api_key <- function() {
+  if (Sys.getenv("WPP_API_KEY") == "") {
+    cli::cli_abort("No API key detected. Set using {.code set_wpp_key_key()} or inside `.Renviron`")
+  }
+}
+
+get_wpp_api_key <- function() {
+  Sys.getenv("WPP_API_KEY")
+}

--- a/R/api_key.R
+++ b/R/api_key.R
@@ -10,5 +10,6 @@ check_wpp_api_key <- function() {
 }
 
 get_wpp_api_key <- function() {
+  check_wpp_api_key()
   Sys.getenv("WPP_API_KEY")
 }

--- a/R/get_base_levels.R
+++ b/R/get_base_levels.R
@@ -4,6 +4,7 @@
 #' querying from the WPP API
 #' 
 #' @param target String, one of "Indicators" or "locations"
+#' @param .progress Boolean, whether to show progress bars for query progress. Default TRUE
 #' @return `tibble` containing a wide range of information about the requested endpoint
 #' @export
 #' 
@@ -11,7 +12,7 @@
 #' get_base_levels("Indicators")
 #' get_base_levels("locations")
 #' 
-get_base_levels <- function(target) {
+get_base_levels <- function(target, .progress = TRUE) {
 
   allowed_targets <- c("Indicators", "locations")
   if (!target %in% c("Indicators", "locations")) {
@@ -27,7 +28,9 @@ get_base_levels <- function(target) {
       next_req = httr2::iterate_with_offset("pageNumber", 
       resp_pages = function(resp) { 
         httr2::resp_body_json(resp, simplifyVector = TRUE)$pages 
-      })
+        }
+      ),
+      progress = .progress
     )
   
     if (length(response) != httr2::resp_body_json(response[[1]])$pages) {
@@ -53,6 +56,7 @@ get_base_levels <- function(target) {
 #' @param name Name of the variable to search for
 #' @param type One of "locations" or "Indicators", which dataset to search
 #' @param search Whether to perform simple search/matching. Defaults to TRUE
+#' @param .progress Boolean, whether to show progress bars for query progress. Default TRUE
 #' 
 #' @return `tibble` containing only the matching records. Column `id` is the numeric
 #' id which will be needed downstream
@@ -62,9 +66,9 @@ get_base_levels <- function(target) {
 #' @examples
 #' get_id("Australia", type = "locations")
 #' 
-get_id <- function(name, type, search = TRUE) {
+get_id <- function(name, type, search = TRUE, .progress = TRUE) {
   
-  search_dataset <- get_base_levels(type)
+  search_dataset <- get_base_levels(type, .progress = .progress)
 
   if (type == "Indicators") {
     search_dataset <- search_dataset[, c("id", "name", "shortName", "description")]

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -35,7 +35,7 @@
 #' @examples
 #' aus_id <- get_id("Australia", type = "locations", search = FALSE, .progress = FALSE)
 #' age_id <- get_id("Population by 5-year age groups and sex", type = "Indicators", search = FALSE, .progress = FALSE)
-#' get_data(indicator_id = age_id$id, location_id = aus_id$id)
+#' get_indicator_data(indicator_id = age_id$id, location_id = aus_id$id)
 #' 
 #' @export
 get_indicator_data <- function(indicator_id, location_id, start_year = 1950, end_year = 2100, .progress = TRUE) {
@@ -46,6 +46,8 @@ get_indicator_data <- function(indicator_id, location_id, start_year = 1950, end
   if (end_year < start_year) {
     cli::cli_abort("`end_year` {end_year} is less than `start_year` {start_year}")
   }
+
+  check_wpp_api_key()
 
   base_url <- "https://population.un.org/dataportalapi/api/v1/data" 
 

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -1,0 +1,82 @@
+#' Get WPP data on an indicator from a specific location
+#'
+#' Get data for a specific indicator, for a specific location from the WPP API
+#' You will need to get the ID of indicators and locations from [get_id] to pass
+#' into this.
+#' 
+#' Note: This function looks for your WPP API key in the environment variable
+#' `WPP_API_KEY`. You can set this using [set_wpp_api_key] or in your `.Renviron`
+#' file.
+#' 
+#' @param indicator_id Numeric ID for the indicator. Common choices include:
+#' \itemize{
+#'   \item 46: Age by sex in 5 year age groups
+#'   \item 47: Age by sex in 1 year age groups
+#' }
+#' 
+#' @param location_id Numeric ID for the location (country)
+#' @param start_year Numeric. Year to start estimates. Minimum 1950, maximum 2100. Default 1950.
+#' @param end_year Numeric. Year to end estimates. Minimum 1951, maximum 2100. Default 2100.
+#' @param .progress Boolean. Whether to show progress bars for query. Default TRUE.
+#' 
+#' @return `tibble` with the following columns:
+#' \itemize{
+#'   \item `locationId`: Numeric ID of location
+#'   \item `location`: Description of location
+#'   \item `iso3`: 3-character country code of location
+#'   \item `iso2`: 2-character country code of location
+#'   \item `locationTypeId`:
+#'   \item `indicatorId`: Numeric ID of indicator
+#'   \item `indicator`: Description of indicator
+#'   \item `indicatorDisplayName`: Publishable display name of indicator
+#' }
+#' 
+#' 
+#' @examples
+#' aus_id <- get_id("Australia", type = "locations", search = FALSE, .progress = FALSE)
+#' age_id <- get_id("Population by 5-year age groups and sex", type = "Indicators", search = FALSE, .progress = FALSE)
+#' get_data(indicator_id = age_id$id, location_id = aus_id$id)
+#' 
+#' @export
+get_indicator_data <- function(indicator_id, location_id, start_year = 1950, end_year = 2100, .progress = TRUE) {
+
+  assertthat::is.number(start_year)
+  assertthat::is.number(end_year)
+
+  if (end_year < start_year) {
+    cli::cli_abort("`end_year` {end_year} is less than `start_year` {start_year}")
+  }
+
+  base_url <- "https://population.un.org/dataportalapi/api/v1/data" 
+
+  response <- httr2::request(base_url) |> 
+    httr2::req_url_path_append(
+      "indicators", indicator_id,
+      "locations", location_id,
+      "start", start_year,
+      "end", end_year
+    ) |>
+    httr2::req_url_query(
+      pagingInHeader = "false",
+      format = "json"
+    ) |>
+    httr2::req_auth_bearer_token(Sys.getenv("WPP_API_KEY")) |>
+    httr2::req_cache(path = tempfile()) |>
+    httr2::req_perform_iterative(
+      next_req = httr2::iterate_with_offset(
+        "pageNumber", 
+        resp_pages = function(resp) { 
+          httr2::resp_body_json(resp, simplifyVector = TRUE)$pages 
+          }
+      ),
+      max_reqs = Inf,
+      progress = .progress
+    )
+  
+  response_data <- lapply(response, function(r) {
+      body <- httr2::resp_body_json(r, simplifyVector = TRUE)
+      
+      tibble::as_tibble(body$data)
+    }) |>
+    dplyr::bind_rows()
+}

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -47,8 +47,6 @@ get_indicator_data <- function(indicator_id, location_id, start_year = 1950, end
     cli::cli_abort("`end_year` {end_year} is less than `start_year` {start_year}")
   }
 
-  check_wpp_api_key()
-
   base_url <- "https://population.un.org/dataportalapi/api/v1/data" 
 
   response <- httr2::request(base_url) |> 
@@ -62,7 +60,7 @@ get_indicator_data <- function(indicator_id, location_id, start_year = 1950, end
       pagingInHeader = "false",
       format = "json"
     ) |>
-    httr2::req_auth_bearer_token(Sys.getenv("WPP_API_KEY")) |>
+    httr2::req_auth_bearer_token(get_wpp_api_key()) |>
     httr2::req_cache(path = tempfile()) |>
     httr2::req_perform_iterative(
       next_req = httr2::iterate_with_offset(

--- a/man/get_base_levels.Rd
+++ b/man/get_base_levels.Rd
@@ -4,10 +4,12 @@
 \alias{get_base_levels}
 \title{Get parameter inputs for population data API}
 \usage{
-get_base_levels(target)
+get_base_levels(target, .progress = TRUE)
 }
 \arguments{
 \item{target}{String, one of "Indicators" or "locations"}
+
+\item{.progress}{Boolean, whether to show progress bars for query progress. Default TRUE}
 }
 \value{
 \code{tibble} containing a wide range of information about the requested endpoint

--- a/man/get_id.Rd
+++ b/man/get_id.Rd
@@ -4,7 +4,7 @@
 \alias{get_id}
 \title{IDs of indicators}
 \usage{
-get_id(name, type, search = TRUE)
+get_id(name, type, search = TRUE, .progress = TRUE)
 }
 \arguments{
 \item{name}{Name of the variable to search for}
@@ -12,6 +12,8 @@ get_id(name, type, search = TRUE)
 \item{type}{One of "locations" or "Indicators", which dataset to search}
 
 \item{search}{Whether to perform simple search/matching. Defaults to TRUE}
+
+\item{.progress}{Boolean, whether to show progress bars for query progress. Default TRUE}
 }
 \value{
 \code{tibble} containing only the matching records. Column \code{id} is the numeric
@@ -21,6 +23,6 @@ id which will be needed downstream
 Get numeric IDs of indicators and locations for the WPP API
 }
 \examples{
-get_id("Australia", typ = "locations")
+get_id("Australia", type = "locations")
 
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(populaR)
+
+test_check("populaR")

--- a/tests/testthat/_snaps/base-levels.md
+++ b/tests/testthat/_snaps/base-levels.md
@@ -1,0 +1,46 @@
+# base levels
+
+    Code
+      get_base_levels("locations", .progress = FALSE)
+    Output
+      # A tibble: 298 x 6
+            id name                iso3  iso2  longitude latitude
+         <int> <chr>               <chr> <chr>     <dbl>    <dbl>
+       1     4 Afghanistan         AFG   AF        67.7      33.9
+       2     8 Albania             ALB   AL        20.2      41.2
+       3    12 Algeria             DZA   DZ         1.66     28.0
+       4    16 American Samoa      ASM   AS      -171.      -14.3
+       5    20 Andorra             AND   AD         1.52     42.5
+       6    24 Angola              AGO   AO        17.9     -11.2
+       7    28 Antigua and Barbuda ATG   AG       -61.8      17.1
+       8    31 Azerbaijan          AZE   AZ        47.6      40.1
+       9    32 Argentina           ARG   AR       -63.6     -38.4
+      10    36 Australia           AUS   AU       134.      -25.3
+      # i 288 more rows
+
+---
+
+    Code
+      get_base_levels("Indicators", .progress = FALSE)
+    Output
+      # A tibble: 64 x 33
+            id name         shortName description displayName dimAge dimSex dimVariant
+         <int> <chr>        <chr>     <chr>       <chr>       <lgl>  <lgl>  <lgl>     
+       1     1 Contracepti~ CPAnyP    Percentage~ Any         FALSE  FALSE  TRUE      
+       2     2 Contracepti~ CPModP    Percentage~ CP Modern   FALSE  FALSE  TRUE      
+       3     3 Contracepti~ CPTrad    Percentage~ CP Traditi~ FALSE  FALSE  TRUE      
+       4     4 Unmet need ~ UNMP      Percentage~ Unmet need  FALSE  FALSE  TRUE      
+       5     5 Unmet need ~ UNMModP   Percentage~ Unmet need~ FALSE  FALSE  TRUE      
+       6     6 Total deman~ DEMTot    Percentage~ Total dema~ FALSE  FALSE  TRUE      
+       7     7 Demand for ~ DEMAny    Percentage~ Demand sat~ FALSE  FALSE  TRUE      
+       8     8 Demand for ~ DEMMod    Percentage~ Demand sat~ FALSE  FALSE  TRUE      
+       9     9 Contracepti~ CPAnyN    Number of ~ Contracept~ FALSE  FALSE  TRUE      
+      10    10 Contracepti~ CPModN    Number of ~ Users of m~ FALSE  FALSE  TRUE      
+      # i 54 more rows
+      # i 25 more variables: dimCategory <lgl>, defaultAgeId <int>,
+      #   defaultSexId <int>, defaultVariantId <int>, defaultCategoryId <int>,
+      #   variableType <chr>, valueType <chr>, unitScaling <dbl>, precision <int>,
+      #   isThousandSeparatorSpace <lgl>, formatString <chr>, unitShortLabel <chr>,
+      #   unitLongLabel <chr>, nClassesDefault <int>, downloadFileName <chr>,
+      #   sourceId <int>, sourceName <chr>, sourceYear <int>, ...
+

--- a/tests/testthat/test-base-levels.R
+++ b/tests/testthat/test-base-levels.R
@@ -1,0 +1,7 @@
+test_that("base levels", {
+  # We have to use progress FALSE because differences in loading
+  # times cause this test to failçç
+  expect_snapshot(get_base_levels("locations", .progress = FALSE))
+
+  expect_snapshot(get_base_levels("Indicators", .progress = FALSE))
+})


### PR DESCRIPTION
Now that the API key issue is sorted, I've added the following functionality

- getters/setters/checkers for the API key, which I expect to be stored in `WPP_API_KEY`
- method for getting data from the aptly named `data` endpoint
- filterable by year (as required by the API)

There's still some documentation on the output dataset, and probably a discussion on which columns we want to include, if that isn't all of them, as many are duplicated across the dataset.